### PR TITLE
Bootstrapping application parts refactoring. Resolve #11

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -77,8 +77,22 @@ export default {
      * @example { name: 'module', priority: 1 } will run `module` immediately
      */
     bootstrap: [
-        { name: 'superadmin', priority: 10 },
-        { name: 'fixtures', priority: 1 },
+        /* run before server start */
+        { name: 'waterline', priority: 10 },
+
+        /* initialze routes & middleware for oure instance of Express server */
+        { name: 'middleware', priority: 20 },
+        { name: 'routes', priority: 20 },
+
+        /* less important, still start before server initialisation */
+        { name: 'superadmin', priority: 30 },
+        { name: 'fixtures', priority: 30 },
+
+        /* initialise server (start listening on given port etc.) */
+        { name: 'server', priority: 40 },
+
+        /* run after server will start */
+        { name: 'websockets', priority: 50 },
     ],
 
     /**

--- a/server/bootstrap/fixtures.js
+++ b/server/bootstrap/fixtures.js
@@ -39,7 +39,7 @@ export default (app) => {
                       if(error) {
                           reject(error);
                       } else {
-                          resolve();
+                          resolve(app);
                       }
                   });
             })

--- a/server/bootstrap/middleware.js
+++ b/server/bootstrap/middleware.js
@@ -1,8 +1,5 @@
 import middleware from '../middleware';
 
 export default (app) => {
-    return new Promise((resolve, reject) => {
-       middleware(app);
-       resolve(app);
-    });
+    return Promise.resolve(middleware(app));
 }

--- a/server/bootstrap/middleware.js
+++ b/server/bootstrap/middleware.js
@@ -1,0 +1,8 @@
+import middleware from '../middleware';
+
+export default (app) => {
+    return new Promise((resolve, reject) => {
+       middleware(app);
+       resolve(app);
+    });
+}

--- a/server/bootstrap/routes.js
+++ b/server/bootstrap/routes.js
@@ -1,8 +1,5 @@
 import routes from '../routes';
 
 export default (app) => {
-    return new Promise((resolve, reject) => {
-       routes(app);
-       resolve(app);
-    });
+    return Promise.resolve(routes(app));
 }

--- a/server/bootstrap/routes.js
+++ b/server/bootstrap/routes.js
@@ -1,0 +1,8 @@
+import routes from '../routes';
+
+export default (app) => {
+    return new Promise((resolve, reject) => {
+       routes(app);
+       resolve(app);
+    });
+}

--- a/server/bootstrap/server.js
+++ b/server/bootstrap/server.js
@@ -1,14 +1,13 @@
 import http from 'http';
 
 export default (app) => {
-    return new Promise((resolve, reject) => {
-        let port = app.config.get('port');
-        let server = http.createServer(app).listen(port);
 
-        app.server = server;
+    let port = app.config.get('port');
+    let server = http.createServer(app).listen(port);
 
-        app.log('info', '[ message ] Listening at port %s', port);
+    app.server = server;
 
-        resolve(app);
-    });
+    app.log('info', '[ message ] Listening at port %s', port);
+
+    return Promise.resolve(app);
 }

--- a/server/bootstrap/server.js
+++ b/server/bootstrap/server.js
@@ -1,0 +1,14 @@
+import http from 'http';
+
+export default (app) => {
+    return new Promise((resolve, reject) => {
+        let port = app.config.get('port');
+        let server = http.createServer(app).listen(port);
+
+        app.server = server;
+
+        app.log('info', '[ message ] Listening at port %s', port);
+
+        resolve(app);
+    });
+}

--- a/server/bootstrap/superadmin.js
+++ b/server/bootstrap/superadmin.js
@@ -20,7 +20,7 @@ export default (app) => {
                          } else {
                              app.log(
                                  'info',
-                                 'Created superadmin account %s',
+                                 '[ message ] Created superadmin account %s',
                                  JSON.stringify(user, null, 4)
                              );
 
@@ -30,7 +30,7 @@ export default (app) => {
              } else {
                  app.log(
                      'info',
-                     'Existing superadmin account %s',
+                     '[ message ] Existing superadmin account %s',
                      JSON.stringify(user, null, 4)
                  );
 
@@ -38,7 +38,7 @@ export default (app) => {
                   * We are not returning user to keep consistency
                   * with case when we are not running `superadmin` feature
                   **/
-                 resolve();
+                 resolve(app);
              }
          });
     });

--- a/server/bootstrap/waterline.js
+++ b/server/bootstrap/waterline.js
@@ -1,0 +1,26 @@
+/**
+ * Models are shared with client
+ */
+import models from '../models';
+
+export default (app) => {
+    return new Promise((resolve, reject) => {
+        /**
+         * Models have to be initialized before routing is invoked
+         */
+        models.waterline.initialize(app.config.get('waterline'), (error, models) => {
+
+            if(error) {
+                reject(error);
+            }
+
+            /**
+             * Expose Waterline `collections` and `connections` for app object
+             */
+        	app.models = models.collections;
+        	app.connections = models.connections;
+
+            resolve(app);
+        });
+    });
+}

--- a/server/bootstrap/websockets.js
+++ b/server/bootstrap/websockets.js
@@ -4,17 +4,5 @@
 import websocket from '../websocket';
 
 export default (app) => {
-    return new Promise((resolve, reject) => {
-
-        if(typeof app.server !== 'undefined') {
-            
-            /* Initialize websocket server */
-            websocket(app.server);
-
-            resolve(app);
-        } else {
-            reject('No `app.server` instance provided.');
-        }
-
-    });
+    return Promise.resolve(websocket(app));
 }

--- a/server/bootstrap/websockets.js
+++ b/server/bootstrap/websockets.js
@@ -1,0 +1,20 @@
+/**
+ * Websocket events and messages
+ */
+import websocket from '../websocket';
+
+export default (app) => {
+    return new Promise((resolve, reject) => {
+
+        if(typeof app.server !== 'undefined') {
+            
+            /* Initialize websocket server */
+            websocket(app.server);
+
+            resolve(app);
+        } else {
+            reject('No `app.server` instance provided.');
+        }
+
+    });
+}

--- a/server/index.js
+++ b/server/index.js
@@ -11,21 +11,10 @@ import config from 'config';
 import logger from './utils/logger';
 
 /**
- * Models are shared with client
+ * Config driven bootstrapping part of apps,
+ * ie. fixtures, server initialisation, websockets
  */
-import models from './models';
-
-/**
- * Routing & middleware
- */
-import routes from './routes';
-import middleware from './middleware';
 import bootstrap from './bootstrap';
-
-/**
- * Websocket events and messages
- */
-import websocket from './websocket';
 
 /**
  * Initialize Express.js server instance
@@ -38,43 +27,5 @@ const app = express();
 app.config = config;
 app.log = logger();
 
-/**
- * Models have to be initialized before routing is invoked
- */
-models.waterline.initialize(config.get('waterline'), (err, models) => {
-
-    if(err) {
-        throw err;
-    }
-
-    /**
-     * Expose Waterline `collections` and `connections` for app object
-     */
-	app.models = models.collections;
-	app.connections = models.connections;
-
-    /**
-     * Initialze routes & middleware for oure instance of Express server
-     */
-    middleware(app);
-    routes(app);
-
-    /**
-     * Comparing to `routes` & `middleware`, bootstraped features
-     * can be async, handle them with promises then
-     */
-    bootstrap(app)
-        .then(() => {
-             const server = app.listen(config.get('port'));
-             app.log('info', 'Listening at port %s', config.get('port'));
-
-             /* Initialize websocket server */
-             websocket(server);
-        })
-        .catch((e) => {
-            /* @TODO: think about better error output, red color perhaps? */
-            app.log('info', ('FATAL, ' + e));
-        });
-});
-
-export default app;
+/* @TODO: think about better error output, red color perhaps? */
+export default bootstrap(app).catch((e) => { app.log('info', ('FATAL, ' + e)); });

--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -32,7 +32,7 @@ export default function (app) {
 
             app.log(
                 'info',
-                'Registred [ middleware ] { name: %s, path: %s, priority: %s }',
+                '[ load:middleware ] { name: %s, path: %s, priority: %s }',
                 name, path, priority
             );
     });

--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -36,4 +36,6 @@ export default function (app) {
                 name, path, priority
             );
     });
+
+    return app;
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -25,7 +25,7 @@ export default function (app) {
              **/
             app.use(path, factory(app));
 
-            app.log('info', 'Registred [ route ]: { path: %s }', path);
+            app.log('info', '[ load:route ]: { path: %s }', path);
         });
     });
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -28,4 +28,6 @@ export default function (app) {
             app.log('info', '[ load:route ]: { path: %s }', path);
         });
     });
+
+    return app;
 }

--- a/server/websocket/handlers/test.js
+++ b/server/websocket/handlers/test.js
@@ -1,4 +1,8 @@
-/* export handlers collection with socket instance injected */
+/**
+ * Attach handlers to provided `socket` instance
+ * @param  {Object} socket Socket.io WebSockets instance
+ * @return {Void}
+ */
 export const handlers = (socket) => {
     socket.on('test', () => {
         console.log('Test socket message arrived');

--- a/server/websocket/index.js
+++ b/server/websocket/index.js
@@ -1,24 +1,27 @@
-/* core dependencies */
 import socketio from 'socket.io';
-
-/* require whole directory */
 import requireDir from 'require-dir';
 
-/* set socket handlers map to use same method for initializing all handlers */
-const files = requireDir('./handlers', { recurse: true });
+export default function (app) {
 
-export default function (server) {
+    if(typeof app.server === 'undefined') {
+        throw new Error('No `app.server` instance provided.');
+    }
+
+    /* set socket handlers map to use same method for initializing all handlers */
+    const files = requireDir('./handlers', { recurse: true });
+
     /* initialize websocket server based on express application instance */
-    const socketServer = socketio(server);
+    app.sockets = socketio(app.server);
 
     /* initialize socket messages handlers when new connection starts */
-    socketServer.on('connection', (socket) => {
+    app.sockets.on('connection', (socket) => {
         Object.keys(files).forEach((file) => {
-            var { handlers } = files[file];
+
+            let { handlers } = files[file];
 
             handlers(socket);
         });
     });
 
-    return socketServer;
+    return app;
 }


### PR DESCRIPTION
**Refactoring**
- bootstrap as waterfall of promises so other modules are waiting for modules initialised  asynchronously before them
- websockets, database collections, middleware and routing as part of application bootstrap
- server initialising as part of application bootstrap (this way we can bootstrap modules before & after server starts to listen)
- Node.js `server` instance exposed with `app.server`
- server manual creation (100% compatible with `app.listen` according to docs)
- `server` module is now exposing bootstrap promise (returning `app` instance), especially helpful when waiting for server full initialisation during tests

**Update**
This branch is also slightly changing log messages for readability.

**Update 2**
Second commit is also simplifying a bit synchronous modules bootstrapping, replacing `new Promise` with `Promise.resolve()`. Also it's making API more consistent by resolving **all** modules with `app` instance and expecting only `app` instance as argument.
