### PR TITLE
Add Dockerfile and docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:latest
+
+# MongoDB
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.2 main" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+RUN apt-get update && apt-get install -y mongodb-org
+RUN mkdir -p /data/db
+
+# Workspace preparation
+RUN mkdir app/
+RUN git clone https://github.com/appmazing/expressify-express-starterkit.git app/
+WORKDIR "app/expressify-express-starterkit/"
+RUN npm install
+
+# Environment variables
+ENV DOCKERIZED=true
+ENV PORT=3000
+
+# Default port exposing
+EXPOSE 3000
+
+# Start MongoDB and App
+CMD service mongod start && npm start

--- a/config/custom-environment-variables.js
+++ b/config/custom-environment-variables.js
@@ -1,0 +1,3 @@
+export default {
+    port: 'PORT',
+};

--- a/config/default.js
+++ b/config/default.js
@@ -8,7 +8,7 @@ import path from 'path';
 const rootDirectory = process.cwd();
 
 export default {
-    port: process.env.PORT || 5001,
+    port: 5001,
     staticDir: path.join(rootDirectory, 'static'),
 
     /* default superadmin credentials */


### PR DESCRIPTION
To build container you just simply use `docker build -t IMAGE_NAME .` 

To run container use `docker run IMAGE_NAME`

If you wish to publish ports and share docker container within your localhost:
- Set `PORT` env variable
- Expose this port with `-e` flag
- Tunnel this port with `-p` flag

So, if you want to run expressify on port 3333 - use: 

``` javascript
docker run --env PORT=3333 -p 3333:3333 -e 3333:3333 IMAGE_NAME
```

As far as i know, there is no other way to tunnel ports except doing it explicitly in `run` command.

I've also added `env` variable called `DOCKERIZED` and im setting it to `true` just to be able to detect if app is running from docker container :)

@cypherq 
